### PR TITLE
Changed Version of Java Fx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 dependencies {
     implementation 'junit:junit:4.13.1'
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.0')
-    implementation 'org.openjfx:javafx-plugin:0.0.13'
+    //implementation 'org.openjfx:javafx-plugin:0.0.13'
 }
 
 java {
@@ -27,7 +27,7 @@ test {
 }
 
 javafx {
-    version = '12'
+    version = '17'
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.base', 'javafx.graphics', 'javafx.media' ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ repositories {
 dependencies {
     implementation 'junit:junit:4.13.1'
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.0')
-    //implementation 'org.openjfx:javafx-plugin:0.0.13'
 }
 
 java {
@@ -34,5 +33,3 @@ javafx {
 application {
     mainClassName = 'src/main/java/MountainClimberApp.java'
 }
-
-apply plugin: "org.openjfx.javafxplugin"

--- a/src/main/java/com/mg105/entities/Item.java
+++ b/src/main/java/com/mg105/entities/Item.java
@@ -1,5 +1,4 @@
 package com.mg105.entities;
-
 public abstract class Item {
     final private String NAME;
     final private String DESCRIPTION;


### PR DESCRIPTION
I changed the version of java FX so that it works for mac silicon. The new version is 17. I also changed some of the build.gradle folder so it does not have depreciated implementation.