### PR TITLE
Add Automatic Javadoc and Gradle Builds

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -27,8 +27,6 @@ jobs:
           arguments: javadoc
       - name: Create .nojekyll File
         run: touch build/docs/javadoc/.nojekyll
-      - name: Set Domain Name
-        run: echo "docs.mg105.com" > build/docs/javadoc/CNAME
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 jobs:
   docs-site:
-    name: docs.mg105.com Javadoc
+    name: Javadoc Website
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -54,12 +54,22 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: distZip
+      - name: Generate Javadoc
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: javadoc
+      - name: Zip Javadoc
+        working-directory: build/docs/javadoc
+        run: zip -r ../../distributions/javadoc.zip .
+      - name: Tar Javadoc
+        working-directory: build/docs/javadoc
+        run: tar czf ../../distributions/javadoc.tar.gz .
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
           name: Prerelease for ${{ github.sha }}
           body: This release is created automatically via GitHub actions. Its artifacts are based on ${{ github.sha }}.
-          tag: prerelease
           commit: ${{ github.sha }}
+          tag: prerelease-${{ github.sha }}
           prerelease: true
           artifacts: 'build/distributions/*'

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,31 @@
+name: Create Distribution Packages
+on:
+  push:
+    branches:
+      - main
+permissions:
+  checks: write
+  actions: read
+  contents: write
+jobs:
+  docs-site:
+    name: Generate docs.mg105.com
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Generate Javadoc
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: javadoc
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build/docs/javadoc

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 jobs:
   docs-site:
-    name: Generate docs.mg105.com
+    name: docs.mg105.com Javadoc
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -33,3 +33,33 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/docs/javadoc
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Generate Tarball Distribution
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: distTar
+      - name: Generate Zip Distribution
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: distZip
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: Prerelease for ${{ github.sha }}
+          body: This release is created automatically via GitHub actions. Its artifacts are based on ${{ github.sha }}.
+          tag: prerelease
+          commit: ${{ github.sha }}
+          prerelease: true
+          artifacts: 'build/distributions/*'

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,4 +1,4 @@
-name: Create Distribution Packages
+name: Distribution Packages
 on:
   push:
     branches:
@@ -25,6 +25,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: javadoc
+      - name: Create .nojekyll File
+        run: touch build/docs/javadoc/.nojekyll
+      - name: Set Domain Name
+        run: echo "docs.mg105.com" > build/docs/javadoc/CNAME
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -65,9 +65,9 @@ jobs:
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          name: Prerelease for ${{ github.sha }}
+          name: 'Prerelease #${{ github.run_number }}'
           body: This release is created automatically via GitHub actions. Its artifacts are based on ${{ github.sha }}.
           commit: ${{ github.sha }}
-          tag: prerelease-${{ github.sha }}
+          tag: prerelease-${{ github.run_number }}
           prerelease: true
           artifacts: 'build/distributions/*'

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -44,14 +44,10 @@ jobs:
           distribution: 'adopt'
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Generate Tarball Distribution
+      - name: Generate Pre-built Jars
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: distTar
-      - name: Generate Zip Distribution
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: distZip
+          arguments: assembleDist
       - name: Generate Javadoc
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           folder: build/docs/javadoc
   release:
-    name: Release
+    name: GitHub Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Program Tests
-on: [push]
+on: [push, pull_request]
 permissions:
   checks: write
   actions: read

--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,5 @@ javafx {
 }
 
 application {
-    mainClassName = 'com.mg105.Main'
+    mainClassName = 'com.mg105.Launcher'
 }

--- a/src/main/java/com/mg105/Application.java
+++ b/src/main/java/com/mg105/Application.java
@@ -10,7 +10,6 @@ import com.mg105.use_cases.MapGenerator;
 import com.mg105.use_cases.RoomGetter;
 import com.mg105.user_interface.*;
 import javafx.animation.AnimationTimer;
-import javafx.application.Application;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
@@ -20,20 +19,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * The main class that sets up the clean architecture mountain group 105 game!
+ * Effectively, the main class that sets up the clean architecture mountain group 105 game!
  */
-public class Main extends Application {
+public class Application extends javafx.application.Application {
     private final TutorialTextDisplay tutorialDisplay = new TutorialTextDisplay();
     private Label bottomText;
-
-    /**
-     * The main method.  See Main.start().
-     *
-     * @param args the commandline arguments.  They are passed to JavaFX.
-     */
-    public static void main(String[] args) {
-        Main.launch(args);
-    }
 
     /**
      * Note that while this isn't our main method explicitly, we (probably) need this to effectively be our main method

--- a/src/main/java/com/mg105/Launcher.java
+++ b/src/main/java/com/mg105/Launcher.java
@@ -1,0 +1,18 @@
+package com.mg105;
+
+/**
+ * Our 'main' class.
+ */
+public class Launcher {
+    /**
+     * The real main method.  All it does is start JavaFX on our Application class.
+     * <p>
+     * Note that this is separate from Application because of how JavaFX decides to do dependencies.
+     * See <a href="https://github.com/nus-cs2103-AY2021S1/forum/issues/128">this GitHub issue</a>.
+     *
+     * @param args The commandline arguments.  They are passed to JavaFX.
+     */
+    public static void main(String[] args) {
+        javafx.application.Application.launch(Application.class, args);
+    }
+}

--- a/src/main/java/com/mg105/controllers/TutorialTextController.java
+++ b/src/main/java/com/mg105/controllers/TutorialTextController.java
@@ -28,7 +28,7 @@ public class TutorialTextController {
     /**
      * Get an instance of the PlayerGetsTutorial use case
      *
-     * @ return the tutorial instance
+     * @return the tutorial instance
      */
     public PlayerGetsTutorial getTutorial() {
         return this.tutorial;


### PR DESCRIPTION
This PR adds GitHub actions that accomplish the following:

- Build and deploy up to date Javadoc to GitHub pages.
- Automatically create a GitHub release for each merge to the `main` branch.

*Note to my group members: you can see an example deployment [here](https://6167656e74323431.github.io/course-project-group-105/) and an example release [here](https://github.com/6167656e74323431/course-project-group-105/releases/tag/prerelease-11)*

*Note to the grader: this work was done on a fork rather than a branch, this is because I ~~can't~~shouldn't test if something works on the main branch.*