### PR TITLE
Added forfeit option to battle

### DIFF
--- a/src/main/java/com/mg105/use_cases/ReplayGenerator.java
+++ b/src/main/java/com/mg105/use_cases/ReplayGenerator.java
@@ -71,8 +71,17 @@ public class ReplayGenerator {
      * Replay the game by interacting with the MapGenerator class
      */
     public void replay() {
+        //Handles the forfeit case, where party is not empty yet.
+        state.getFainted().addAll(state.getParty());
+        state.setParty(new BattleCharacter[] {});
+
+        //Party is empty, fainted is full.
+        state.getParty().addAll(state.getFainted());
+        state.getFainted().removeAll(state.getParty());
+
         this.inventoryClean();
         this.attributeInheritance();
+
         // incomplete remake, need to amend later. exactly implementation should depend
         // on other use cases' implementation
         MapGenerator isekai = new MapGenerator(state);

--- a/src/main/java/com/mg105/use_cases/battle/BattleInteractor.java
+++ b/src/main/java/com/mg105/use_cases/battle/BattleInteractor.java
@@ -56,22 +56,6 @@ public class BattleInteractor {
      * Creates a new encounter with random opponents and sets it as the current encounter in GameState.
      */
     public void createEncounter() {
-        /* OLD RANDOMLY GENERATED OPPONENTS CODE
-        Random rand = new Random();
-
-        ArrayList<BattleCharacter> opponents = new ArrayList<>();
-
-        for (int i = 0; i < 4; ++i){
-            int charHealth = rand.nextInt(5, 41);
-            int charDmg = rand.nextInt(1, 11);
-            int charSpeed = rand.nextInt(3, 16);
-            Move m1 = new Move(-rand.nextInt(1, 8), 0, "first", false);
-            Move m2 = new Move(rand.nextInt(1, 4), 0, "second", true);
-            BattleCharacter character = new BattleCharacter(charHealth, "Opponent " + i,
-                charDmg, charSpeed, true, m1, m2);
-            opponents.add(character);
-        }
-         */
         ArrayList<BattleCharacter> opponents = new ArrayList<>(state.getCurrOpponent().getOpponents());
         ArrayList<BattleCharacter> party = this.state.getParty();
         Battle b = new Battle(opponents, party);
@@ -311,12 +295,9 @@ public class BattleInteractor {
         if (status == 1) {
             addReward();
             return true;
-        } else if (status == -1) {
-            state.getParty().addAll(state.getFainted());
-            state.getFainted().removeAll(state.getParty());
         }
 
-        // since at this point status != 0, status must == -1 (battle was lost)
+        // status must == -1 (battle was lost) or 0 (battle was forfeited)
         return false;
     }
 

--- a/src/main/java/com/mg105/user_interface/BattleMenu.java
+++ b/src/main/java/com/mg105/user_interface/BattleMenu.java
@@ -37,6 +37,8 @@ public class BattleMenu implements EventHandler<ActionEvent>, BattleMenuInterfac
     private final Label o3 = new Label();
 
     private final Button nextRound;
+
+    private final Button forfeit;
     private final Button moveOne;
     private final Button moveTwo;
 
@@ -71,6 +73,11 @@ public class BattleMenu implements EventHandler<ActionEvent>, BattleMenuInterfac
         nextRound.setId("Next Round");
         nextRound.setOnAction(this);
         grid.add(nextRound, 10, 30);
+
+        forfeit = new Button("Forfeit");
+        forfeit.setId("Forfeit");
+        forfeit.setOnAction(this);
+        grid.add(forfeit, 10, 2);
 
         grid.add(p0, 1, 4);
         grid.add(p1, 1, 8);
@@ -294,6 +301,8 @@ public class BattleMenu implements EventHandler<ActionEvent>, BattleMenuInterfac
                 nextRound.setDisable(false);
             }
 
+        } else if (source.equals(forfeit)) {
+            presenter.endBattle();
         } else if(source.equals(moveOne)) {
             moveNum = 1;
             displayTargets();


### PR DESCRIPTION
- Added forfeit button in BattleMenu to avoid situation where healer character can only heal themselves more than opponent can damage them, leading to never ending battle. BattlePresenter.endBattle() is called with battle status == 0. Modified party/fainted reset code to accommodate for losing with a non-empty party.
- Moved party/fainted reset code from BattleInteractor.endBattle() to ReplayGenerator.replay().
- Removed old commented-out BattleInteractor.createEncounter() random generation code.